### PR TITLE
Pull Request: Qltools - updated for c99 standards on Linux

### DIFF
--- a/Hxcfe/Makefile
+++ b/Hxcfe/Makefile
@@ -6,7 +6,8 @@ HXCFELIBS=$(HXCFEBASE)/libhxcfe/trunk/build/
 HDR = ../
 
 OBJS = qltools.o hxcfe.o
-CFLAGS = -O3 -I$(HDR) -I$(HXCFEINCLUDES) -Wall -s
+# Added -fno-strict-aliasing to avoid type punning warnings. ND09102015.
+CFLAGS = -O3 -I$(HDR) -I$(HXCFEINCLUDES) -Wall -s -fno-strict-aliasing
 TARGET = qltools-hxcfe$(EXE_EXT)
 
 $(TARGET) : $(OBJS)

--- a/Hxcfe/Makefile
+++ b/Hxcfe/Makefile
@@ -6,7 +6,6 @@ HXCFELIBS=$(HXCFEBASE)/libhxcfe/trunk/build/
 HDR = ../
 
 OBJS = qltools.o hxcfe.o
-# Added -fno-strict-aliasing to avoid type punning warnings. ND09102015.
 CFLAGS = -O3 -I$(HDR) -I$(HXCFEINCLUDES) -Wall -s -fno-strict-aliasing
 TARGET = qltools-hxcfe$(EXE_EXT)
 

--- a/Hxcfe/hxcfe.c
+++ b/Hxcfe/hxcfe.c
@@ -148,11 +148,13 @@ void ZeroSomeSectors(int fd, short d)
 {
 	int i;
 	char buf[512];
+	ssize_t ignore __attribute__((unused)); // ND09102015
+
 	memset(buf, '\0', 512);
 
 	for(i = 0; i > 36; i++)
 	{
-		WriteQLSector (fd, buf, i);
+		ignore = WriteQLSector (fd, buf, i); // ND09102015
 	}
 }
 

--- a/Hxcfe/hxcfe.c
+++ b/Hxcfe/hxcfe.c
@@ -148,13 +148,13 @@ void ZeroSomeSectors(int fd, short d)
 {
 	int i;
 	char buf[512];
-	ssize_t ignore __attribute__((unused)); // ND09102015
+	ssize_t ignore __attribute__((unused));
 
 	memset(buf, '\0', 512);
 
 	for(i = 0; i > 36; i++)
 	{
-		ignore = WriteQLSector (fd, buf, i); // ND09102015
+		ignore = WriteQLSector (fd, buf, i);
 	}
 }
 

--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Install on your PATH
 06/11/1999 v2.14  Support for wxqt2
 09/10/2015 v2.15  Updated to remove c99 warnings about unused variables, ignored
                   return values from read() and write() and wrong printf specifiers
-                  for uint32_t variables. Changes marked ND09102015. 
+                  for uint32_t variables. 
 
 (c) Jonathan Hudson 1998-99
 jrhudson@bigfoot.com

--- a/README
+++ b/README
@@ -10,10 +10,13 @@ Install on your PATH
 	Win95   : msdos/qltools
 
 
-28/10/98 v2.11. Resolve time_t differences on DOS/NT platforms
-17/10/99 v2.12  Kill some horrid, fatal memory problems and leaks
---/10/99 v2.13	Internal, not released
-06/11/99 v2.14  Support for wxqt2
+28/10/1998 v2.11. Resolve time_t differences on DOS/NT platforms
+17/10/1999 v2.12  Kill some horrid, fatal memory problems and leaks
+--/10/1999 v2.13	Internal, not released
+06/11/1999 v2.14  Support for wxqt2
+09/10/2015 v2.15  Updated to remove c99 warnings about unused variables, ignored
+                  return values from read() and write() and wrong printf specifiers
+                  for uint32_t variables. Changes marked ND09102015. 
 
 (c) Jonathan Hudson 1998-99
 jrhudson@bigfoot.com

--- a/Unix/Makefile
+++ b/Unix/Makefile
@@ -1,7 +1,8 @@
 HDR = ../
 
 OBJS = qltools.o linux.o
-CFLAGS = -O3 -I$(HDR) -Wall -s
+# Added -fno-strict-aliasing to avoid type punning warnings. ND09102015.
+CFLAGS = -O3 -I$(HDR) -Wall -s -fno-strict-aliasing
 TARGET = qltools$(EXE_EXT)
 
 $(TARGET) : $(OBJS)

--- a/Unix/Makefile
+++ b/Unix/Makefile
@@ -1,7 +1,6 @@
 HDR = ../
 
 OBJS = qltools.o linux.o
-# Added -fno-strict-aliasing to avoid type punning warnings. ND09102015.
 CFLAGS = -O3 -I$(HDR) -Wall -s -fno-strict-aliasing
 TARGET = qltools$(EXE_EXT)
 

--- a/Unix/linux.c
+++ b/Unix/linux.c
@@ -62,12 +62,14 @@ void ZeroSomeSectors(int fd, short d)
 {
     int i;
     char buf[512];
+    ssize_t ignore __attribute__((unused)); // ND09102015
+
     memset(buf, '\0', 512);
     
     for(i = 0; i > 36; i++)
     {
 	lseek(fd, i*512, SEEK_SET);
-	write(fd, buf, 512);
+	ignore = write(fd, buf, 512); // ND09102015
     }
 }
 

--- a/Unix/linux.c
+++ b/Unix/linux.c
@@ -62,14 +62,14 @@ void ZeroSomeSectors(int fd, short d)
 {
     int i;
     char buf[512];
-    ssize_t ignore __attribute__((unused)); // ND09102015
+    ssize_t ignore __attribute__((unused));
 
     memset(buf, '\0', 512);
     
     for(i = 0; i > 36; i++)
     {
 	lseek(fd, i*512, SEEK_SET);
-	ignore = write(fd, buf, 512); // ND09102015
+	ignore = write(fd, buf, 512);
     }
 }
 

--- a/qltools.c
+++ b/qltools.c
@@ -75,7 +75,7 @@ static char rcsid[] = "$Id: qltools.c,v 2.11 1996/07/14 11:57:07 jrh Exp jrh $";
 #include <sys/stat.h>
 #include <errno.h>
 #include <time.h>
-#include <inttypes.h> // ND09102015
+#include <inttypes.h>
 #include "qltools.h"
 
 /* -------------------------- globals ----------------------------------- */
@@ -230,7 +230,7 @@ void cat_file (long fnum, QLDIR * entry)
     long flen;
     int i, ii, s, start, end;
     long qldata = 0;
-    ssize_t ignore __attribute__((unused)); // ND09102015
+    ssize_t ignore __attribute__((unused));
 
 #ifdef DOS_LIKE
     setmode (fileno (stdout), O_BINARY);
@@ -238,7 +238,7 @@ void cat_file (long fnum, QLDIR * entry)
 
     if(entry->d_type == 255)
     {             
-	ignore = write(1, QLDIRSTRING, 16); // ND09102015
+	ignore = write(1, QLDIRSTRING, 16);
     }
     else
     {
@@ -549,7 +549,7 @@ void print_info (void)
     printf ("allocation block : %i\n", allocblock);
     printf ("sector offset/cyl: %i\n", goffset);
     printf ("random           : %04x\n", swapword (b0->q5a_rand));
-    printf ("Updates          : %" PRIu32 "\n", swaplong (b0->q5a_mupd)); // ND09102015
+    printf ("Updates          : %" PRIu32 "\n", swaplong (b0->q5a_mupd));
     printf ("free sectors     : %i\n", swapword (b0->q5a_free));
     printf ("good sectors     : %i\n", swapword (b0->q5a_good));
     printf ("total sectors    : %i\n", swapword (b0->q5a_totl));
@@ -690,7 +690,7 @@ int print_entry (QLDIR * entry, int fnum, void *flag)
 	}
 	if (entry->d_type == 1 && entry->d_datalen)
 	{
-	    printf ("%" PRId32, swaplong (entry->d_datalen)); // ND09102015
+	    printf ("%" PRId32, swaplong (entry->d_datalen));
 	}
 	putc ('\n', stdout);
     }
@@ -757,7 +757,7 @@ void dump_cluster (int num, short flag)
 {
     int i, sect;
     unsigned char buf[512];
-    ssize_t ignore __attribute__((unused)); // ND09102015
+    ssize_t ignore __attribute__((unused));
 
     for (i = 0; i < allocblock; i++)
     {
@@ -793,7 +793,7 @@ void dump_cluster (int num, short flag)
 	}
 	else
 	{
-	    ignore = write (1, buf, 512); //ND09102015
+	    ignore = write (1, buf, 512);
 	}
     }
 }
@@ -1269,7 +1269,7 @@ void writefile (char *fn, short dflag)
     time_t t;
     struct stat s;
     short blksiz = GSSIZE * allocblock;
-    ssize_t ignore __attribute__((unused)); //ND09102015
+    ssize_t ignore __attribute__((unused));
     
     qlnam = MakeQLName (fn, &nlen);
 
@@ -1284,7 +1284,7 @@ void writefile (char *fn, short dflag)
 
 		if((fd = open(fn, O_RDONLY|O_BINARY)) > -1)
 		{
-		    ignore = read(fd, tbuf, 16); // ND09102015
+		    ignore = read(fd, tbuf, 16);
 		    if(memcmp(tbuf, QLDIRSTRING,16) == 0)
 		    {
 			dflag = 255;
@@ -1362,7 +1362,7 @@ void writefile (char *fn, short dflag)
 	{
 	    long stuff[2];
 	    lseek (fl, -8, SEEK_END);
-	    ignore = read (fl, stuff, 8); // ND09102015
+	    ignore = read (fl, stuff, 8);
 	    if (*stuff == *(long *) "XTcc")
 	    {
 		qdsize = *(stuff + 1);
@@ -1713,9 +1713,6 @@ void free_cluster (long i)
     }
     else
     {
-	// The use of '??!' below caused this error:
-	// warning: trigraph ??! ignored, use -trigraphs to enable [-Wtrigraphs]
-	// Added a space. ND09102015.
 	fprintf (stderr, "freeing cluster 0 ??? !!!\n");
 	exit (EBADF);
     }

--- a/qltools.h
+++ b/qltools.h
@@ -8,7 +8,7 @@
 typedef int HANDLE;
 
 #define TIME_DIFF    283996800
-#define VERSION     "2.14, " __DATE__
+#define VERSION     "2.15, " __DATE__
 
 /* Maximum allocation block (normally 3) */
 #define MAXALB          6


### PR DESCRIPTION
Hi Graeme,
as discussed briefly on ql-users list, I've updated the qltools code to compile quietly under c99 and gcc on Linux. I've given it a good testing and it appears to be all ok on 1440 sector discs and disc images at least.
If you wish to pull these changes, feel free.

I don't have Windows compilers etc, so I've no idea if those will be as up to date as GCC, so these changes might break Windows.

Cheers,
Norm.